### PR TITLE
add extends to html snippets in twig.snippets

### DIFF
--- a/snippets/twig.snippets
+++ b/snippets/twig.snippets
@@ -1,5 +1,6 @@
 # Basic Twig snippets
 # Maintainer: F. Gabriel Gosselin <gabrielNOSPAM@evidens.ca>
+extends html
 
 # include
 snippet inc


### PR DESCRIPTION
With this change html snippets work  in  twig templates ( tested with Ultisnips )
