### PR TITLE
Restore indentexpr after calling external indent method.

### DIFF
--- a/indent/twig.vim
+++ b/indent/twig.vim
@@ -20,7 +20,12 @@ fun! GetTwigIndent(currentLineNumber)
 		return indent(previousOpenStructureNumber)
 	endif
 
-    return s:CallBaseIndent()
+    let indent = s:CallBaseIndent()
+    " Restore indentexpr 
+    setlocal indentexpr=GetTwigIndent(v:lnum)
+    " Restore twig syntax.
+    unlet b:main_syntax | runtime! syntax/twig.vim
+    return indent
 endf
 
 function! s:CallBaseIndent()


### PR DESCRIPTION
The value of ``indentexpr`` might be reset by external methods, so it is
necessary to restore it after calling an external method.