### PR TITLE
Add Twig Blocks to % match

### DIFF
--- a/ftplugin/twig.vim
+++ b/ftplugin/twig.vim
@@ -10,6 +10,27 @@ setlocal comments=s:{#,ex:#}
 setlocal formatoptions+=tcqln
 " setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\|^[-*+]\\s\\+
 
+if exists('b:match_words')
+    let b:twigMatchWords = [
+                \ ['block', 'endblock'],
+                \ ['for', 'endfor'],
+                \ ['macro', 'endmacro'],
+                \ ['if', 'elseif', 'else', 'endif'],
+                \ ['set', 'endset']
+                \]
+    for s:element in b:twigMatchWords
+        let s:pattern = ''
+        for s:tag in s:element[:-2]
+            if s:pattern != ''
+                let s:pattern .= ':'
+            endif
+            let s:pattern .= '{%\s*\<' . s:tag . '\>\s*\%(.*=\)\@![^}]\{-}%}'
+        endfor
+        let s:pattern .= ':{%\s*\<' . s:element[-1:][0] . '\>\s*.\{-}%}'
+        let b:match_words .= ',' . s:pattern
+    endfor
+endif
+
 if exists("b:did_ftplugin")
   let b:undo_ftplugin .= "|setlocal comments< formatoptions<"
 else


### PR DESCRIPTION
This is a config I use in my own dotfiles and @ahmedelgabri suggested I make a PR.

It basically allows <kbd>%</kbd> to match twig blocks like `if/elesif/else/endif`, `set/endset`.

Let me know if anything needs changing :)